### PR TITLE
Disable warning about unused function

### DIFF
--- a/source/plutovg-stb-truetype.h
+++ b/source/plutovg-stb-truetype.h
@@ -505,6 +505,10 @@ int main(int arg, char **argv)
 #define STBTT_DEF extern
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This is causing a large number of warnings when built in wxWidgets